### PR TITLE
Update create-certificates.sh

### DIFF
--- a/scripts/create-certificates.sh
+++ b/scripts/create-certificates.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export PATH=$BIN_DIR:$PATH
-EASYRSA_PINNED_COMMIT=1600b3f 
+EASYRSA_PINNED_COMMIT=354c20d 
 
 if ! command -v git 1> /dev/null 2> /dev/null; then
   echo "git cli not found" >&2


### PR DESCRIPTION
updated pinned version to 3.1.2 to fix    on ../main.tf line 35, in resource “null_resource” “create_certificates”:
│   35:   provisioner “local-exec” {
│
│ Error running command ‘../scripts/create-certificates.sh’: exit status 1. Output: Cloning easy-rsa
│ Cloning into ‘easy-rsa’...
│ Note: switching to ‘1600b3f’.
│
│ You are in ‘detached HEAD’ state. You can look around, make experimental
│ changes and commit them, and you can discard any commits you make in this
│ state without impacting any branches by switching back to a branch.
│
│ If you want to create a new branch to retain commits you create, you may
│ do so (now or later) by using -c with the switch command. Example: